### PR TITLE
feat: fetch all categories without pagination

### DIFF
--- a/src/controllers/category.controller.js
+++ b/src/controllers/category.controller.js
@@ -23,6 +23,16 @@ class CategoryController {
         }
     }
 
+    async getAllCategoriesList(req, res, next) {
+        try {
+            const categories = await CategoryService.getAllCategoriesList(req.query);
+            return res.status(httpStatus.OK).json({ success: true, data: categories });
+        } catch (error) {
+            logger.error('Get all categories failed:', error);
+            next(error);
+        }
+    }
+
     async getCategoryById(req, res, next) {
         try {
             const category = await CategoryService.getCategoryById(req.params.id);

--- a/src/routes/user/category.route.js
+++ b/src/routes/user/category.route.js
@@ -4,6 +4,6 @@ const CategoryController = require('../../controllers/category.controller');
 const router = express.Router();
 
 
-router.get('/', CategoryController.getAllCategories);
+router.get('/', CategoryController.getAllCategoriesList);
 
 module.exports = router; 

--- a/src/services/category.service.js
+++ b/src/services/category.service.js
@@ -42,6 +42,33 @@ class CategoryService {
         }
     }
 
+    async getAllCategoriesList({ sortBy = 'createdAt', isActive, parentId }) {
+        try {
+            const filter = {};
+            if (isActive !== undefined) filter.isActive = isActive;
+            if (parentId) filter.parentId = parentId;
+
+            let sort = 'createdAt';
+            if (sortBy) {
+                sort = sortBy
+                    .split(',')
+                    .map(pair => {
+                        const [key, order] = pair.split(':');
+                        return (order === 'desc' ? '-' : '') + key;
+                    })
+                    .join(' ');
+            }
+
+            const categories = await Category.find(filter)
+                .sort(sort)
+                .populate('parentId');
+            return categories;
+        } catch (error) {
+            logger.error('Error fetching all categories:', error);
+            throw new ApiError(httpStatus.INTERNAL_SERVER_ERROR, 'Error fetching categories');
+        }
+    }
+
     async getCategoryById(id) {
         try {
             const category = await Category.findById(id).populate('parentId');


### PR DESCRIPTION
## Summary
- add service method to fetch all categories as a list
- expose controller and user route without pagination

## Testing
- `npm test` *(fails: SyntaxError: Identifier 'jest' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68af44bc0304832bb93a09ca090cacd5